### PR TITLE
fix(enrichment): add persistence callback to fix race condition

### DIFF
--- a/packages/community/src/lib/storage.ts
+++ b/packages/community/src/lib/storage.ts
@@ -131,6 +131,18 @@ export class StorageService implements IStorage {
 
     if (config.enabled && hasCredentials) {
       this.enrichmentService = new EnrichmentService(config);
+
+      // Set callback to persist enriched memories to IndexedDB
+      // This fixes the race condition where enrichment completes but data isn't persisted
+      this.enrichmentService.onEnrichmentComplete = async (memory: MemoryWithMemA) => {
+        try {
+          await this.db.memories.put(memory);
+          logger.log(`[Storage] Persisted enriched memory: ${memory.id}`);
+        } catch (error) {
+          logger.error(`[Storage] Failed to persist enriched memory:`, error);
+        }
+      };
+
       logger.log(`Enrichment service initialized (provider: ${config.provider})`);
     } else {
       logger.log(`Enrichment service NOT initialized: enabled=${config.enabled}, hasCredentials=${hasCredentials}`);
@@ -197,6 +209,17 @@ export class StorageService implements IStorage {
     // Re-initialize enrichment service if enabled
     if (config.enabled && hasCredentials) {
       this.enrichmentService = new EnrichmentService(config);
+
+      // Set callback to persist enriched memories to IndexedDB
+      this.enrichmentService.onEnrichmentComplete = async (memory: MemoryWithMemA) => {
+        try {
+          await this.db.memories.put(memory);
+          console.log(`[Storage] Persisted enriched memory: ${memory.id}`);
+        } catch (error) {
+          console.error(`[Storage] Failed to persist enriched memory:`, error);
+        }
+      };
+
       console.log(`[Storage] Enrichment service re-initialized (provider: ${config.provider})`);
     } else {
       console.log(`[Storage] Enrichment service NOT re-initialized: enabled=${config.enabled}, hasCredentials=${hasCredentials}`);
@@ -751,19 +774,12 @@ export class StorageService implements IStorage {
     logger.log('Enriching memory with content:', memoryForEnrichment.content.text.substring(0, 100) + '...');
 
     // Trigger enrichment (non-blocking queue processing)
+    // The onEnrichmentComplete callback will handle persistence after enrichment completes
     await this.enrichmentService.enrichMemory(memoryForEnrichment);
 
-    // Copy back the enrichment data if we used a temporary object
-    if (memoryForEnrichment !== memory) {
-      memory.keywords = memoryForEnrichment.keywords;
-      memory.tags = memoryForEnrichment.tags;
-      memory.context = memoryForEnrichment.context;
-      // @ts-ignore
-      memory.memAVersion = memoryForEnrichment.memAVersion;
-    }
-
-    // Persist the enriched metadata to DB (bypass saveMemory hooks to avoid recursion)
-    await this.db.memories.put(memory);
+    // NOTE: We don't persist here anymore because enrichment is async (queued)
+    // The callback (onEnrichmentComplete) will persist after enrichment actually completes
+    // This fixes the race condition where unenriched data was being persisted
 
     // Regenerate embedding with enhanced metadata (keywords + context + tags)
     try {


### PR DESCRIPTION
Fixes critical architectural issue where enrichment data was modified in-memory but never persisted to IndexedDB.

## Problem
1. enrichInBackground() queued enrichment and returned immediately
2. It then tried to persist memory assuming enrichment was complete
3. But enrichment actually happened async in background
4. Result: Memory persisted WITHOUT enriched data (keywords, tags, context)
5. When tests waited and retrieved memory, enrichment data was missing

## Solution
Implement callback pattern for post-enrichment persistence:

1. **EnrichmentService**:
   - Added `onEnrichmentComplete` callback property
   - Call callback after enrichment completes in `enrichSingle()`
   - Callback persists enriched memory to database

2. **StorageService**:
   - Set callback during enrichment service initialization
   - Callback uses `db.memories.put()` to persist enriched memory
   - Applied to both initial and re-initialization paths

3. **enrichInBackground()**:
   - Removed premature persistence (line 789)
   - Now callback handles persistence after enrichment completes
   - Fixes race condition with clear comment

## Technical Details
- Callback pattern avoids circular dependency (EnrichmentService → StorageService)
- Enrichment completes → callback fires → memory persisted with enriched data
- Tests can now wait for enrichment and retrieve enriched data from DB

## Impact
Fixes ~13 integration tests that expect enriched data:
- storage-enrichment.integration.test.ts tests will pass
- Search by keywords/tags will work
- Enrichment stats tracking will work
- Batch enrichment tests will work

## Related
- Issue #2 in TEST_ANALYSIS_REPORT.md (race condition)
- Issue #3 in TEST_ANALYSIS_REPORT.md (missing persistence)
- Test coverage improvement initiative (37% → 67%)