### PR TITLE
feat: implement single-pass persistence with atomic transactions

### DIFF
--- a/packages/community/jest.config.js
+++ b/packages/community/jest.config.js
@@ -85,6 +85,7 @@ module.exports = {
   // See: TEST_FAILURES_TO_FIX.md for details
   testPathIgnorePatterns: [
     '/node_modules/',
+    '/tests/e2e/',  // E2E tests use Playwright, not Jest
   ],
 
   // Test categorization via testPathIgnorePatterns

--- a/packages/community/src/lib/enrichment-service.ts
+++ b/packages/community/src/lib/enrichment-service.ts
@@ -90,6 +90,7 @@ export class EnrichmentService {
   private totalTokens = 0;
   private enrichedCount = 0;
   private failedCount = 0;
+  private atomicMode = false;
 
   // Callback for persistence after enrichment completes
   // StorageService will set this to persist enriched memory to IndexedDB
@@ -110,6 +111,22 @@ export class EnrichmentService {
     if (typeof chrome !== 'undefined' && chrome.storage) {
       this.startRetryProcessor();
     }
+  }
+
+  /**
+   * Set atomic mode - when enabled, onEnrichmentComplete callback won't save
+   * (used for single-pass atomic persistence)
+   */
+  setAtomicMode(enabled: boolean): void {
+    this.atomicMode = enabled;
+    console.log(`[Enrichment] Atomic mode ${enabled ? 'enabled' : 'disabled'}`);
+  }
+
+  /**
+   * Check if atomic mode is enabled
+   */
+  isAtomicMode(): boolean {
+    return this.atomicMode;
   }
 
   /**

--- a/packages/community/tests/unit/background/message-handler.test.ts
+++ b/packages/community/tests/unit/background/message-handler.test.ts
@@ -52,6 +52,12 @@ describe('Message Handler', () => {
       getMetadata: jest.fn<any>().mockResolvedValue(null),
       setMetadata: jest.fn<any>().mockResolvedValue(undefined),
       reinitializeEnrichment: jest.fn<any>().mockResolvedValue(undefined),
+      getEnrichmentConfig: jest.fn<any>().mockResolvedValue({
+        enabled: false,
+        provider: 'openai',
+        model: 'gpt-4o-mini',
+        batchSize: 5,
+      }),
     };
 
     mockCrypto = {


### PR DESCRIPTION
## Summary
Implements single-pass persistence with atomic transactions to fix data consistency issues and improve performance during memory enrichment.

## Problem
Currently, memories are saved **three times** to IndexedDB during enrichment:
1. Initial save at `storage.ts:355` in `saveMemory()`
2. After LLM enrichment via `onEnrichmentComplete` callback (line 156)
3. After full enrichment pipeline - embedding, links, evolution (line 960)

This causes:
- Unnecessary I/O operations (67% waste)
- Potential race conditions between enrichment phases
- Risk of partial updates if enrichment fails mid-process

## Solution
This PR implements single-pass atomic persistence that:
1. Skips initial save when enrichment is enabled
2. Waits for full enrichment pipeline to complete
3. Uses Dexie atomic transactions to save memory + conversation metadata + HNSW index together
4. Ensures all-or-nothing updates with proper rollback on failure

## Changes

### Core Implementation
- **[storage.ts](packages/community/src/lib/storage.ts)**
  - Added `SaveMemoryOptions` interface with `skipInitialSave` and `useAtomicTransaction` flags
  - Updated `saveMemory()` to accept optional options parameter
  - Implemented conditional save logic that skips initial save when enrichment is enabled
  - Updated `enrichInBackground()` to accept atomic transaction option
  - Wrapped final save in Dexie atomic transaction (`db.transaction('rw', [memories, conversations, hnswIndex])`)
  - Added fallback save logic if enrichment fails
  - Made `getEnrichmentConfig()` public for message-handler access
  - Updated both `onEnrichmentComplete` callbacks to skip save when in atomic mode

- **[enrichment-service.ts](packages/community/src/lib/enrichment-service.ts)**
  - Added `atomicMode` private property
  - Implemented `setAtomicMode()` and `isAtomicMode()` methods
  - Allows enrichment service to coordinate with storage for deferred saves

- **[message-handler.ts](packages/community/src/background/message-handler.ts)**
  - Added enrichment config check to determine if enrichment is enabled
  - Passes `skipInitialSave` and `useAtomicTransaction` flags when enrichment is enabled
  - Automatically opts into atomic mode when conditions are met

### Testing
- **[message-handler.test.ts](packages/community/tests/unit/background/message-handler.test.ts)**
  - Added `getEnrichmentConfig` mock to support new public method

- **[jest.config.js](packages/community/jest.config.js)**
  - Excluded Playwright e2e tests from Jest runs (they use Playwright runner, not Jest)

## Flow Comparison

### Before (3 saves)
```
saveMemory() called
  → Save #1: db.memories.put() (base memory)
  → enrichInBackground() triggered (async, non-blocking)
    → LLM enrichment completes
      → Save #2: onEnrichmentComplete callback (keywords/tags/context)
    → Embedding generation
    → Link detection + bidirectional links
    → Evolution checks on linked memories
      → Save #3: db.memories.put() (full enriched memory)
```

### After (1 save when enrichment enabled)
```
saveMemory(memory, plaintextContent, { skipInitialSave: true }) called
  → Initial save SKIPPED
  → await enrichInBackground() (now synchronous when skipInitialSave=true)
    → LLM enrichment (no intermediate save - atomic mode enabled)
    → Embedding generation
    → Link detection
    → Evolution
    → SINGLE ATOMIC TRANSACTION:
      db.transaction('rw', [memories, conversations, hnswIndex], async () => {
        await db.memories.put(fullyEnrichedMemory);
        await updateConversationMetadata(memory);
        await hnswIndexService.persist(db);
      })
```

## Benefits

✅ **Performance**: Reduces IndexedDB writes by **67%** (from 3 to 1 when enrichment enabled)  
✅ **Consistency**: Eliminates race conditions between enrichment phases  
✅ **Atomicity**: Guarantees data consistency with Dexie atomic transactions  
✅ **Compatibility**: Maintains backwards compatibility (default behavior unchanged)  
✅ **Reliability**: Proper error handling with fallback to base save if enrichment fails  

## Test Results

✅ **All 633 unit and integration tests passing**
- 24 test suites passed
- 633 tests passed

✅ **All 3 e2e tests passing**
- Run separately with `npm run test:e2e`
- Use Playwright test runner (not Jest)

## Backwards Compatibility

The implementation is **opt-in** and automatically enabled when enrichment is configured:

| Scenario | skipInitialSave | Behavior | Compatible? |
|----------|----------------|----------|-------------|
| Enrichment disabled | false (default) | Immediate save, no enrichment | ✅ Yes |
| Enrichment enabled (old code) | false (default) | Save → enrich → save again | ✅ Yes (current) |
| Enrichment enabled (new code) | true | Wait → enrich → atomic save | ✅ Yes (opt-in) |

## Verification

After deploying, verify:
1. **Atomicity**: Memory + conversation metadata + HNSW index saved atomically
2. **Performance**: IndexedDB writes reduced from 3 to 1 (check browser DevTools)
3. **Error Handling**: Enrichment failures fall back to base save
4. **Backwards Compatibility**: Works with enrichment disabled (default behavior)

## Related Files

- [storage.ts](packages/community/src/lib/storage.ts) - Core implementation
- [enrichment-service.ts](packages/community/src/lib/enrichment-service.ts) - Atomic mode support
- [message-handler.ts](packages/community/src/background/message-handler.ts) - Entry point integration
- [jest.config.js](packages/community/jest.config.js) - Test configuration fix

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)