### PR TITLE
fix: pass authenticated Supabase client to CloudSyncService

### DIFF
--- a/packages/community/src/background/index.ts
+++ b/packages/community/src/background/index.ts
@@ -429,7 +429,8 @@ class BackgroundService {
       this.cloudSync = new CloudSyncService(
         authState.userId,
         this.crypto,
-        this.getMasterKey()!
+        this.getMasterKey()!,
+        supabaseClient
       );
 
       // Download memories from cloud

--- a/packages/community/src/lib/cloud-sync.ts
+++ b/packages/community/src/lib/cloud-sync.ts
@@ -21,19 +21,23 @@ export class CloudSyncService {
   private onRemoteChangeCallback: ((change: any) => void) | null = null;
   private lastSyncTimestamp: number = 0;
 
-  constructor(userId: string, crypto: CryptoService, masterKey: MasterKey) {
+  constructor(userId: string, crypto: CryptoService, masterKey: MasterKey, authenticatedClient?: SupabaseClient) {
     this.userId = userId;
     this.crypto = crypto;
     this.masterKey = masterKey;
 
-    const supabaseUrl = process.env.PLASMO_PUBLIC_SUPABASE_URL;
-    const supabaseKey = process.env.PLASMO_PUBLIC_SUPABASE_ANON_KEY;
+    if (authenticatedClient) {
+      this.supabase = authenticatedClient;
+    } else {
+      const supabaseUrl = process.env.PLASMO_PUBLIC_SUPABASE_URL;
+      const supabaseKey = process.env.PLASMO_PUBLIC_SUPABASE_ANON_KEY;
 
-    if (!supabaseUrl || !supabaseKey) {
-      throw new Error('Supabase credentials not found in environment');
+      if (!supabaseUrl || !supabaseKey) {
+        throw new Error('Supabase credentials not found in environment');
+      }
+
+      this.supabase = createClient(supabaseUrl, supabaseKey);
     }
-
-    this.supabase = createClient(supabaseUrl, supabaseKey);
   }
 
   /**

--- a/packages/community/tests/integration/cloud-sync-persistence.test.ts
+++ b/packages/community/tests/integration/cloud-sync-persistence.test.ts
@@ -120,7 +120,23 @@ jest.mock('../../src/lib/auth-client', () => ({
         email: 'test@example.com',
       })
     ),
-    getSupabaseClient: jest.fn(() => ({})),
+    getSupabaseClient: jest.fn(() => ({
+      from: jest.fn(() => ({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        is: jest.fn().mockReturnThis(),
+        gt: jest.fn(() => Promise.resolve({ data: [], error: null })),
+        single: jest.fn(() => Promise.resolve({ data: { tier: 'premium', sync_enabled: true }, error: null })),
+        maybeSingle: jest.fn(() => Promise.resolve({ data: null, error: null })),
+        upsert: jest.fn(() => Promise.resolve({ error: null })),
+        update: jest.fn().mockReturnThis(),
+      })),
+      channel: jest.fn(() => ({
+        on: jest.fn(function (this: any) { return this; }),
+        subscribe: jest.fn(function (this: any) { return this; }),
+        unsubscribe: jest.fn(() => Promise.resolve()),
+      })),
+    })),
   },
 }));
 


### PR DESCRIPTION
## Summary

- `CloudSyncService` was instantiating its own anonymous Supabase client (anon key only, no user session), causing all reads/writes against RLS-protected tables (`encrypted_memories`, `profiles`) to be rejected for premium users
- Added an optional `authenticatedClient` parameter to the `CloudSyncService` constructor
- Background service now passes the authenticated client (carrying the user's JWT) when initializing `CloudSyncService`

## Test plan

- [ ] Log in as a premium user with sync enabled
- [ ] Verify memories upload to `encrypted_memories` without RLS errors
- [ ] Verify memories download correctly from cloud
- [ ] Verify real-time sync subscription works across devices
- [ ] Confirm free users are still correctly blocked from sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)